### PR TITLE
Fix output ternary operator

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "sns_topic_arn" {
   description = "The SNS topic that was created"
-  value       = var.sns_topic_arn != null ? aws_sns_topic.this[0].arn : var.sns_topic_arn
+  value       = var.sns_topic_arn != null ? var.sns_topic_arn : aws_sns_topic.this[0].arn
 }


### PR DESCRIPTION
Ordering of the ternary operator is wrong and leads TF to try and output the ARN of a topic it didn't create in the first place.